### PR TITLE
Default path is set from the beginning if possible

### DIFF
--- a/CCleanerUpdaterGUIHelper/Helper.cs
+++ b/CCleanerUpdaterGUIHelper/Helper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Windows.Forms;
 
@@ -31,6 +31,15 @@ namespace CCleanerUpdaterGUIHelper
         {
             InitializeComponent();
             Init();
+           
+            string x64DefaultPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles) + "\\CCleaner";
+            string x86DefaultPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) + "\\CCleaner";
+            if (System.IO.Directory.Exists(x64DefaultPath)) {
+                CCPath.Text = x64DefaultPath;
+            }
+            else if (System.IO.Directory.Exists(x86DefaultPath)) {
+                CCPath.Text = x86DefaultPath;
+            }
         }
 
         private void Init()


### PR DESCRIPTION
If either the x86 or x64 version of _CCleaner_ is installed at the default location,
the programm will now detect and set it as the path for the new installation.

On startup the programm will look like the following:

Before:
![beforepatch](https://user-images.githubusercontent.com/27786664/47958472-2dd42380-dfcc-11e8-98bf-d1cc5154c517.PNG)

After:
![afterpatch](https://user-images.githubusercontent.com/27786664/47958485-33ca0480-dfcc-11e8-8baf-ea621e8aa545.PNG)

