### PR TITLE
language is automatically selected for the user

### DIFF
--- a/CCleanerUpdaterGUIHelper/Helper.cs
+++ b/CCleanerUpdaterGUIHelper/Helper.cs
@@ -31,14 +31,34 @@ namespace CCleanerUpdaterGUIHelper
         {
             InitializeComponent();
             Init();
-           
+        
+            DetectSystemLanguage();
+
             string x64DefaultPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles) + "\\CCleaner";
             string x86DefaultPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) + "\\CCleaner";
-            if (System.IO.Directory.Exists(x64DefaultPath)) {
+
+            if (System.IO.Directory.Exists(x64DefaultPath))
+            {
                 CCPath.Text = x64DefaultPath;
             }
-            else if (System.IO.Directory.Exists(x86DefaultPath)) {
+            else if (System.IO.Directory.Exists(x86DefaultPath))
+            {
                 CCPath.Text = x86DefaultPath;
+            }
+        }
+
+        private void DetectSystemLanguage()
+        {
+            System.Globalization.CultureInfo ci = System.Globalization.CultureInfo.InstalledUICulture; 
+            string sysLang = ci.EnglishName.Split(' ')[0];
+
+            for (int i = 0; i < Languages.Length / 2; i++)
+            {
+                if (Languages[i, 0].Equals(sysLang))
+                {
+                    Lang.SelectedIndex = i;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
On startup, it looks in which language windows is installed. If the found language is compatible, then the language is automatically selected for the user.

For example, I am from germany and my Windows is set to german.

Before:
![beforepatchlanguage](https://user-images.githubusercontent.com/27786664/48006016-28cebb80-e115-11e8-88e2-66ab5df5e8cc.PNG)

After:
![afterpatchlanguage](https://user-images.githubusercontent.com/27786664/48006030-308e6000-e115-11e8-9735-145e4046a99b.PNG)

